### PR TITLE
Fix udev_rules.md 404

### DIFF
--- a/resource/linux/udev_rules.md
+++ b/resource/linux/udev_rules.md
@@ -8,7 +8,7 @@ This is why we use [udev](https://en.wikipedia.org/wiki/Udev), which allows norm
 # Commands to install the rules
 
 ```sh
-wget https://raw.githubusercontent.com/wiiznokes/fan-control/resource/linux/60-fan-control.rules
+wget https://raw.githubusercontent.com/wiiznokes/fan-control/master/resource/linux/60-fan-control.rules
 sudo mv 60-fan-control.rules /usr/lib/udev/rules.d
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```

--- a/resource/linux/udev_rules.md
+++ b/resource/linux/udev_rules.md
@@ -21,7 +21,7 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 ### Steam Os
 
-You need to disable read the read only mode temporarily
+You need to disable the read only mode temporarily
 
 ```sh
 sudo steamos-readonly disable


### PR DESCRIPTION
When I try to download the udev rule with the provided wget command it fails because the file does not exist, it only gets a 404, when adding the "master" to the url the file downloads correctly.