### PR TITLE
Add udev note to the app stream file

### DIFF
--- a/resource/linux/metainfo.xml
+++ b/resource/linux/metainfo.xml
@@ -42,6 +42,8 @@
       <li>Save configuration</li>
       <li xml:lang="de">Konfiguration speichern</li>
     </ul>
+    <p>Note: After installation, you will need to add the necessary udev rule to your system for this to work. See the GitHub page for more details.</p>
+    <p xml:lang="de">Hinweis: Nach der Installation musst du die notwendige udev-Regel zu deinem System hinzufügen, damit dies funktioniert. Auf der GitHub-Seite findest du weitere Details.</p>
   </description>
 
   <launchable type="desktop-id">io.github.wiiznokes.fan-control.desktop</launchable>


### PR DESCRIPTION
This PR adds a note that the user should install the udev rule and where to find more information about it.