### PR TITLE
Update udev_rules.md to use /etc/udev/rules.d/

### DIFF
--- a/resource/linux/udev_rules.md
+++ b/resource/linux/udev_rules.md
@@ -9,7 +9,7 @@ This is why we use [udev](https://en.wikipedia.org/wiki/Udev), which allows norm
 
 ```sh
 wget https://raw.githubusercontent.com/wiiznokes/fan-control/master/resource/linux/60-fan-control.rules
-sudo mv 60-fan-control.rules /usr/lib/udev/rules.d
+sudo mv 60-fan-control.rules /etc/udev/rules.d/
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 


### PR DESCRIPTION
Uses the correct path /etc/udev/rules.d/ (/lib/udev/rules.d/ should be used if making a package)